### PR TITLE
ナビゲーションコンポーネントを共通レイアウトに移動し、メニューの現在位置に下線クラスを付与するようにした

### DIFF
--- a/layouts/navigation.vue
+++ b/layouts/navigation.vue
@@ -36,22 +36,33 @@
           <ul class="md:flex md:justify-end md:items-end">
             <li class="w-full md:w-auto md:ml-5">
               <nuxt-link
+                to="/"
+                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 rounded-md md:hover:underline hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                :class="{ underline: isCurrentPage('') }"
+                >ホーム</nuxt-link
+              >
+            </li>
+            <li class="w-full md:w-auto md:ml-5">
+              <nuxt-link
                 to="/shop"
-                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 rounded-md hover:bg-gray-700 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 rounded-md md:hover:underline hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                :class="{ underline: isCurrentPage('shop') }"
                 >店舗情報</nuxt-link
               >
             </li>
             <li class="w-full md:w-auto md:ml-5">
               <nuxt-link
                 to="/menu"
-                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 rounded-md hover:bg-gray-700 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 rounded-md md:hover:underline hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                :class="{ underline: isCurrentPage('menu') }"
                 >メニュー</nuxt-link
               >
             </li>
             <li class="w-full md:w-auto md:ml-5">
               <nuxt-link
                 to="/information"
-                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 rounded-md hover:bg-gray-700 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 rounded-md md:hover:underline hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                :class="{ underline: isCurrentPage('information') }"
                 >お知らせ</nuxt-link
               >
             </li>
@@ -63,16 +74,26 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from '@nuxtjs/composition-api'
+import { defineComponent, ref, useRoute } from '@nuxtjs/composition-api'
 
 export default defineComponent({
-  name: 'Nav',
+  name: 'Navigation',
   setup() {
+    const route = useRoute()
+
+    const isCurrentPage = (page: string) => {
+      const regExp = new RegExp(`^/${page}$`)
+      return route.value.path.match(regExp)
+    }
+
     const showMenu = ref(false)
+
     const toggleStatus = () => {
       showMenu.value = !showMenu.value
     }
+
     return {
+      isCurrentPage,
       showMenu,
       toggleStatus,
     }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,15 +1,13 @@
 <template>
   <div>
-    <Nav />
     <main></main>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from '@nuxtjs/composition-api'
-import Nav from '@/components/Nav.vue'
 
 export default defineComponent({
-  components: { Nav },
+  layout: 'navigation',
 })
 </script>


### PR DESCRIPTION
## やったこと

- [x] ナビゲーションコンポーネントを共通レイアウトに移動し、メニューの現在位置に下線クラスを付与するようにした

![image](https://user-images.githubusercontent.com/27620649/166708861-2924eef1-a2be-40cb-b05b-977800d619f9.png)

![image](https://user-images.githubusercontent.com/27620649/166708932-4a9a7007-ecd8-4cf4-93b4-e74ebbfe8b99.png)
