### PR TITLE
【アクセシビリティ】ハンバーガーメニューでのスクリーンリーダー及びタブ移動の対応

### DIFF
--- a/layouts/navigation.vue
+++ b/layouts/navigation.vue
@@ -13,32 +13,31 @@
               Nuxt Cafe
             </nuxt-link>
           </h1>
-          <div class="text-white md:hidden">
-            <button class="focus:outline-none" @click="toggleStatus">
-              <!-- ハンバーガーメーニューのSVG：https://reffect.co.jp/html/tailwind-for-beginners-navigation-menu -->
-              <svg
-                v-show="!showMenu"
-                class="w-6 h-6 fill-current"
-                viewBox="0 0 24 24"
-              >
-                <title>メニューを開くボタン</title>
-                <path
-                  d="M24 6h-24v-4h24v4zm0 4h-24v4h24v-4zm0 8h-24v4h24v-4z"
-                />
-              </svg>
-              <svg
-                v-show="showMenu"
-                id="gNav"
-                class="w-6 h-6 fill-current"
-                viewBox="0 0 24 24"
-              >
-                <title>メニューを閉じるボタン</title>
-                <path
-                  d="M24 20.188l-8.315-8.209 8.2-8.282-3.697-3.697-8.212 8.318-8.31-8.203-3.666 3.666 8.321 8.24-8.206 8.313 3.666 3.666 8.237-8.318 8.285 8.203z"
-                />
-              </svg>
-            </button>
-          </div>
+          <button
+            v-show="!showMenu"
+            class="text-white md:hidden focus:outline-none"
+            @click="toggleStatus"
+          >
+            <!-- ハンバーガーメーニューのSVG：https://reffect.co.jp/html/tailwind-for-beginners-navigation-menu -->
+            <svg class="w-6 h-6 fill-current" viewBox="0 0 24 24" tabindex="0">
+              <title>メニューを開くボタン</title>
+              <path d="M24 6h-24v-4h24v4zm0 4h-24v4h24v-4zm0 8h-24v4h24v-4z" />
+            </svg>
+          </button>
+          <button
+            v-show="showMenu"
+            tabindex="0"
+            class="text-white md:hidden focus:outline-none"
+            @click="toggleStatus"
+          >
+            <!-- ハンバーガーメーニューのSVG：https://reffect.co.jp/html/tailwind-for-beginners-navigation-menu -->
+            <svg class="w-6 h-6 fill-current" viewBox="0 0 24 24" tabindex="0">
+              <title>メニューを閉じるボタン</title>
+              <path
+                d="M24 20.188l-8.315-8.209 8.2-8.282-3.697-3.697-8.212 8.318-8.31-8.203-3.666 3.666 8.321 8.24-8.206 8.313 3.666 3.666 8.237-8.318 8.285 8.203z"
+              />
+            </svg>
+          </button>
         </div>
         <nav
           :class="showMenu ? 'sm:block' : 'sm:hidden'"

--- a/layouts/navigation.vue
+++ b/layouts/navigation.vue
@@ -39,6 +39,7 @@
                 to="/"
                 class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
                 :class="{ current: isCurrentPage('') }"
+                :aria-current="isCurrentPage('') ? 'page' : undefined"
                 >ホーム</nuxt-link
               >
             </li>
@@ -47,6 +48,7 @@
                 to="/shop"
                 class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
                 :class="{ current: isCurrentPage('shop') }"
+                :aria-current="isCurrentPage('shop') ? 'page' : undefined"
                 >店舗情報</nuxt-link
               >
             </li>
@@ -55,6 +57,7 @@
                 to="/menu"
                 class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
                 :class="{ current: isCurrentPage('menu') }"
+                :aria-current="isCurrentPage('menu') ? 'page' : undefined"
                 >メニュー</nuxt-link
               >
             </li>
@@ -63,6 +66,9 @@
                 to="/information"
                 class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
                 :class="{ current: isCurrentPage('information') }"
+                :aria-current="
+                  isCurrentPage('information') ? 'page' : undefined
+                "
                 >お知らせ</nuxt-link
               >
             </li>

--- a/layouts/navigation.vue
+++ b/layouts/navigation.vue
@@ -48,7 +48,7 @@
             <li class="w-full md:w-auto md:ml-5">
               <nuxt-link
                 to="/"
-                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-4 md:whitespace-nowrap"
                 :class="{ current: isCurrentPage('') }"
                 :aria-current="isCurrentPage('') ? 'page' : undefined"
                 >ホーム</nuxt-link
@@ -57,7 +57,7 @@
             <li class="w-full md:w-auto md:ml-5">
               <nuxt-link
                 to="/shop"
-                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-4 md:whitespace-nowrap"
                 :class="{ current: isCurrentPage('shop') }"
                 :aria-current="isCurrentPage('shop') ? 'page' : undefined"
                 >店舗情報</nuxt-link
@@ -66,7 +66,7 @@
             <li class="w-full md:w-auto md:ml-5">
               <nuxt-link
                 to="/menu"
-                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-4 md:whitespace-nowrap"
                 :class="{ current: isCurrentPage('menu') }"
                 :aria-current="isCurrentPage('menu') ? 'page' : undefined"
                 >メニュー</nuxt-link
@@ -75,7 +75,7 @@
             <li class="w-full md:w-auto md:ml-5">
               <nuxt-link
                 to="/information"
-                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-4 md:whitespace-nowrap"
                 :class="{ current: isCurrentPage('information') }"
                 :aria-current="
                   isCurrentPage('information') ? 'page' : undefined

--- a/layouts/navigation.vue
+++ b/layouts/navigation.vue
@@ -16,13 +16,24 @@
           <div class="text-white md:hidden">
             <button class="focus:outline-none" @click="toggleStatus">
               <!-- ハンバーガーメーニューのSVG：https://reffect.co.jp/html/tailwind-for-beginners-navigation-menu -->
-              <svg class="w-6 h-6 fill-current" viewBox="0 0 24 24">
+              <svg
+                v-show="!showMenu"
+                class="w-6 h-6 fill-current"
+                viewBox="0 0 24 24"
+              >
+                <title>メニューを開くボタン</title>
                 <path
-                  v-show="!showMenu"
                   d="M24 6h-24v-4h24v4zm0 4h-24v4h24v-4zm0 8h-24v4h24v-4z"
                 />
+              </svg>
+              <svg
+                v-show="showMenu"
+                id="gNav"
+                class="w-6 h-6 fill-current"
+                viewBox="0 0 24 24"
+              >
+                <title>メニューを閉じるボタン</title>
                 <path
-                  v-show="showMenu"
                   d="M24 20.188l-8.315-8.209 8.2-8.282-3.697-3.697-8.212 8.318-8.31-8.203-3.666 3.666 8.321 8.24-8.206 8.313 3.666 3.666 8.237-8.318 8.285 8.203z"
                 />
               </svg>

--- a/layouts/navigation.vue
+++ b/layouts/navigation.vue
@@ -37,32 +37,32 @@
             <li class="w-full md:w-auto md:ml-5">
               <nuxt-link
                 to="/"
-                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 rounded-md md:hover:underline hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
-                :class="{ underline: isCurrentPage('') }"
+                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                :class="{ current: isCurrentPage('') }"
                 >ホーム</nuxt-link
               >
             </li>
             <li class="w-full md:w-auto md:ml-5">
               <nuxt-link
                 to="/shop"
-                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 rounded-md md:hover:underline hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
-                :class="{ underline: isCurrentPage('shop') }"
+                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                :class="{ current: isCurrentPage('shop') }"
                 >店舗情報</nuxt-link
               >
             </li>
             <li class="w-full md:w-auto md:ml-5">
               <nuxt-link
                 to="/menu"
-                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 rounded-md md:hover:underline hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
-                :class="{ underline: isCurrentPage('menu') }"
+                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                :class="{ current: isCurrentPage('menu') }"
                 >メニュー</nuxt-link
               >
             </li>
             <li class="w-full md:w-auto md:ml-5">
               <nuxt-link
                 to="/information"
-                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 rounded-md md:hover:underline hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
-                :class="{ underline: isCurrentPage('information') }"
+                class="inline-block w-full px-5 py-5 text-xl font-bold leading-loose text-gray-300 hover:text-white sm:hover:bg-gray-700 md:block md:py-0 md:px-0"
+                :class="{ current: isCurrentPage('information') }"
                 >お知らせ</nuxt-link
               >
             </li>
@@ -100,3 +100,15 @@ export default defineComponent({
   },
 })
 </script>
+
+<style scoped>
+.current {
+  color: white;
+  border-bottom: 2px solid white;
+
+  /* SP */
+  @media (max-width: 767px) {
+    background-color: #374151;
+  }
+}
+</style>


### PR DESCRIPTION
## やったこと

- [x] [ナビゲーションの中の現在のページ部分には下線と白文字を表示するようにした](https://github.com/Shigeyuki-fukuda/nuxt-nav-sample/commit/60b88cee2736fe4812dbe8be02470f6f14ba8310)
- [x]  [スクリーンリーダーでナビゲーションのリンクで現在のページを示す項目が「現在のページ」と読み上げられるようにaria-current属性をナビゲーションの各要素に追加](https://github.com/Shigeyuki-fukuda/nuxt-nav-sample/commit/e226c111c4a1ea790cf00e77959615446ebd1bc7) 
- [x] [SPの際のハンバーガーメニューを開閉時それぞれで異なるボタンとしてスクリーンリーダーに読み上げられるようにした](https://github.com/Shigeyuki-fukuda/nuxt-nav-sample/commit/afcd147e0a6753c80d98520c1ce1558a4ca7e28b)
- [x] [タブレット以上の幅の際にメニューの各項目が二行になってしまうスタイル崩れを修正](https://github.com/Shigeyuki-fukuda/nuxt-nav-sample/commit/110d6eb64ade84373b11224210249363b9e77019) 
- [x] [SPの際のハンバーガーメニューをtabでフォーカス移動出来るように修正](https://github.com/Shigeyuki-fukuda/nuxt-nav-sample/commit/d19f3e32733a9022c0f257be2efdeb8b99351619)

## キャプチャ

### SP

![image](https://user-images.githubusercontent.com/27620649/167243785-ba2ad03c-cf4b-483e-9146-775e577efdcf.png)

### PC

![image](https://user-images.githubusercontent.com/27620649/167243809-abebae90-b555-43d9-9d44-4ce7f1d2c5e7.png)
